### PR TITLE
Add dynamic frontend menu to admin settings

### DIFF
--- a/app/admin/settings/page.js
+++ b/app/admin/settings/page.js
@@ -1,8 +1,26 @@
+import menuItems from "../../../data/menuItems";
+import Link from "next/link";
+
 export default function SettingsPage() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
-      <h1 className="text-2xl font-bold mb-4">Settings Dashboard</h1>
-      <p className="text-gray-600">This page is under construction.</p>
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-6">
+      <h1 className="text-2xl font-bold mb-6">Settings Dashboard</h1>
+
+      <nav className="bg-white shadow rounded w-full max-w-xs p-4">
+        <ul className="space-y-2 text-sm">
+          {menuItems
+            .filter((item) => item.title && item.href)
+            .map((item, index) => (
+              <li key={index}>
+                <Link href={item.href} className="text-[#009992] hover:underline">
+                  {item.title}
+                </Link>
+              </li>
+            ))}
+        </ul>
+      </nav>
+
+      <p className="text-gray-600 mt-6">This page is under construction.</p>
       <p className="text-gray-600">Stay tuned for updates!</p>
     </div>
   );


### PR DESCRIPTION
## Summary
- display front-end menu items in Admin Settings

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685afd09fdcc832eaf78531f6c37baaf