### PR TITLE
Fix admin accueil API

### DIFF
--- a/app/api/admin/accueil-data/route.js
+++ b/app/api/admin/accueil-data/route.js
@@ -1,51 +1,33 @@
 //app/api/admin/accueil-data/route.js
 
-// import { NextResponse } from "next/server";
-// import { connectDb } from "../../../../lib/db.mjs";
-// import AccueilWeb from "../../../../models/Accueil-web.mjs";
+import { NextResponse } from "next/server";
+import { connectDb } from "../../../../lib/db.mjs";
+import AccueilWeb from "../../../../models/Accueil-web.mjs";
 
-// export const dynamic = "force-dynamic";
+export const dynamic = "force-dynamic";
 
-// export async function GET() {
-//   try {
-//     await connectDb();
+export async function GET() {
+  try {
+    await connectDb();
+    const doc = await AccueilWeb.findOne().lean();
 
-//     const doc = await AccueilWeb.findOne().lean();
+    if (!doc) {
+      return NextResponse.json({
+        heroTitleLine1: "",
+        heroTitleLine2: "",
+        heroTitleLine3: "",
+        heroTitleLine4: "",
+        heroTitleLine5: "",
+        heroImageUrl: "",
+        soinsSection: { title: "", subtitle: "", tagline: "" },
+        aboutSection: { title: "", paragraphs: [] },
+      });
+    }
 
-//     if (!doc) {
-//       return NextResponse.json({
-//         heroTitleLine1: "",
-//         heroTitleLine2: "",
-//         heroTitleLine3: "",
-//         heroTitleLine4: "",
-//         heroTitleLine5: "",
-//         heroImageUrl: "",
-//         soinsSection: { title: "", subtitle: "", tagline: "" },
-//         aboutSection: { title: "", paragraphs: [] },
-//       }, { status: 200 });
-//     }
-
-//     return NextResponse.json(doc);
-//   } catch (err) {
-//     console.error("Erreur API Accueil:", err);
-//     return NextResponse.json({ error: "Server error" }, { status: 500 });
-//   }
-// }
-
-
-
-export const metadata = {
-  title: 'Pause Réflexo',
-  description: 'Site Pause Réflexo',
-};
-
-export default function RootLayout({ children }) {
-  return (
-    <html lang="fr">
-      <body>
-        {children}
-      </body>
-    </html>
-  );
+    return NextResponse.json(doc);
+  } catch (err) {
+    console.error("Erreur API Accueil:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
 }
 


### PR DESCRIPTION
## Summary
- restore proper GET handler for `/api/admin/accueil-data`
- remove stray layout export from API route

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b4c725f58832e8fc80b3f918e8ad2